### PR TITLE
enable nfsv3

### DIFF
--- a/exporter/run_nfs
+++ b/exporter/run_nfs
@@ -27,8 +27,8 @@ function start()
     mount -t nfsd nfds /proc/fs/nfsd
 
     # from /lib/systemd/system/rpcbind.service
-#    . /etc/sysconfig/rpcbind
-#    /sbin/rpcbind -w ${RPCBIND_ARGS}
+    . /etc/sysconfig/rpcbind
+    /usr/sbin/rpcbind -w ${RPCBIND_ARGS}
 
     # from /lib/systemd/system/nfs-config.service
     /usr/lib/systemd/scripts/nfs-utils_env.sh
@@ -40,7 +40,7 @@ function start()
     # from /lib/systemd/system/nfs-server.service
     . /run/sysconfig/nfs-utils
     /usr/sbin/exportfs -r
-    /usr/sbin/rpc.nfsd -N 2 -N 3 -V 4 -V 4.1 $RPCNFSDARGS
+    /usr/sbin/rpc.nfsd -N 2 -V 3 -V 4 -V 4.1 $RPCNFSDARGS
 
     echo "NFS started"
 }

--- a/nfs-server-pod.yaml
+++ b/nfs-server-pod.yaml
@@ -1,17 +1,19 @@
-apiVersion: v1beta1
+apiVersion: v1
 kind: Pod
-id: nfs-server
-desiredState:
-  manifest:
-    version: v1beta1
-    id: nfs-server
-    containers:
-      - name: nfs-server
-        image: jsafrane/nfs-data
-        privileged: true
-        ports:
-          - name: nfs
-            containerPort: 2049
-            protocol: tcp
-labels:
+metadata:
   name: nfs-server
+  labels:
+    role: nfs-server
+spec:
+  containers:
+    - name: nfs-server
+      image: jsafrane/nfs-data
+      ports:
+        - name: nfs
+          containerPort: 2049
+        - name: rpcbind
+          containerPort: 111
+        - name: mountd
+          containerPort: 20048
+      securityContext:
+        privileged: true


### PR DESCRIPTION
Run nfs server container:

``` console
# docker run -ti --privileged --net=host  -p 2049:2049 -p 20048:20048 -p 111:111/udp -p 111:111/tcp  hchen/nfs-data
Serving /mnt/data
NFS started
```

NFS client (on the same host):

``` console
mount -t nfs localhost:/mnt/data /tmp/mnt -o vers=3,nolock
```
